### PR TITLE
v0.0.3 added support for windows os

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)  
 
-**v0.0.2**  
+**v0.0.3**  
 
 #
 
@@ -14,9 +14,9 @@ happy_little_helpers is a python package that gives you some happy little utils 
 easy flash drive credential management for moving from system to system.
 
 ```
-get_flash_path() - get the path to your credentials flash drive automatically 
+get_flash_path(root_directory) - get the path to your credentials flash drive automatically 
 
-read_env() - check you are retrieving the right credentials
+read_env(flash_path) - check things are working using test credentials
 ```
 ## debugger
 
@@ -60,8 +60,11 @@ happy-little-helpers
 
 ```
 
-export PYTHONPATH=/home/<username>>/Documents/github/happy-little-helpers/happy_little_helpers:$PYTHONPATH
+Linux (Tested in Ubuntu):
+export PYTHONPATH=/home/<username>/Documents/github/happy-little-helpers/src:$PYTHONPATH
 
+Windows 10:
+export PYTHONPATH=C:\Users\<username>\Documents\github\happy-little-helpers\src:$PYTHONPATH
 ```
 
 2. format a flash drive and name the partition `credentials`. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "happy-little-helpers"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
     { name = "wyattlovesgrapes", email = "wyattlovesgrapes@gmail.com" }
 ]

--- a/src/happy_little_helpers/debugger.py
+++ b/src/happy_little_helpers/debugger.py
@@ -1,6 +1,7 @@
 # Default Setting
 DEBUG_MODE = False
 
+
 def debug_print(message):
     """
     Print the message if debug mode is enabled.

--- a/src/happy_little_helpers/flash_env.py
+++ b/src/happy_little_helpers/flash_env.py
@@ -6,11 +6,22 @@ from happy_little_helpers.debugger import debug_print
 
 def get_flash_path(root_directory):
 
-    if os.name == 'nt':  # 'nt' indicates Windows
-        debug_print('Operating System: Windows')
-    elif platform.system() == 'Linux':
+    if os.name == "nt":  # 'nt' indicates Windows
         # Print OS
-        debug_print('Operating System: Linux')
+        debug_print("Operating System: Windows")
+
+        # Get flashdrive path prefix
+        path_prefix = _get_windows_drive_path_prefix()
+
+        # Construct path for windows
+        flash_drive_path = os.path.join(path_prefix, root_directory, ".env")
+
+        # Print root_directory
+        debug_print("Root Directory: " + root_directory)
+
+    elif platform.system() == "Linux":
+        # Print OS
+        debug_print("Operating System: Linux")
 
         # Get root directory and username
         username = _get_linux_username()
@@ -19,30 +30,50 @@ def get_flash_path(root_directory):
         flash_drive_path = f"/media/{username}/credentials/{root_directory}/.env"
         debug_print("Flash drive path (Linux): " + flash_drive_path)
 
-    elif platform.system() == 'Darwin':
-        debug_print('Operating System: MacOS')
+    elif platform.system() == "Darwin":
+        debug_print("Operating System: MacOS")
         # macOS
     else:
-        debug_print('Operating System: Other')
+        debug_print("Operating System: Other")
         # Handle other operating systems here
         flash_drive_path = None
 
     return flash_drive_path
 
 
-
 def read_env(flash_drive_path):
-    # Read the contents of the .env file and print it to the console
     try:
-        with open(flash_drive_path, 'r') as file:
+        with open(flash_drive_path, "r") as file:
             env_contents = file.read()
             debug_print("Contents of .env file:")
             debug_print(env_contents)
     except FileNotFoundError:
         debug_print(".env file not found at the specified path.")
 
+
 def _get_linux_username():
-    # Get the current username
     username = getpass.getuser()
     debug_print("Username: " + username)
     return username
+
+
+def _get_windows_drive_path_prefix():
+    drives = []
+    # Get all available drive letters
+    for drive in range(ord("A"), ord("Z") + 1):
+        drive_letter = chr(drive) + ":"
+        if os.path.exists(drive_letter):
+            drives.append(drive_letter)
+
+    # Iterate through each drive and check if the volume label matches
+    for drive in drives:
+        volume_label = "credentials"
+        try:
+            check_label = os.popen(f"vol {drive}").read().split("\n")[0].split(" ")[-1]
+        except Exception as e:
+            pass
+        if check_label == volume_label:
+            debug_print("Drive: " + drive)
+            return drive
+
+    return

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,7 +3,6 @@ from happy_little_helpers.debugger import enable_debug_mode
 
 enable_debug_mode()
 
-flash_path = get_flash_path('code-tests')
+flash_path = get_flash_path("happy-little-helpers")
 
 read_env(flash_path)
-

--- a/tests/pythonpath.txt
+++ b/tests/pythonpath.txt
@@ -1,2 +1,7 @@
 Add to project directory temporarily to test module:
+
+Linux (Tested in Ubuntu):
 export PYTHONPATH=/home/<username>/Documents/github/happy-little-helpers/src:$PYTHONPATH
+
+Windows 10:
+export PYTHONPATH=C:\Users\<username>\Documents\github\happy-little-helpers\src:$PYTHONPATH


### PR DESCRIPTION
## Changes v0.0.3

- Updated ```pythonpath.txt``` to include commands for adding test paths for both Windows and Linux
- Updated name of test-credentials project name in main_test.py to `get_flash_path('happy-little-helpers')`
- Added internal function to get windows path prefix `_get_windows_drive_path_prefix()`
- Added support for Windows to `flash_env`